### PR TITLE
Disallow use of Module.p.require

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,17 @@
 
 > A secure require implementation for ECMAScript
 
+![npm](https://img.shields.io/npm/v/secure-require.svg)
+
 Feel more confident running a bunch of untrusted dependencies as a part of your
 application or module by allowing said dependency to only use a subset of core
 APIs. This allows you to make sure that none of the sub-dependencies try
 anything unexpected, or are able to alter the global objects of your own application
 code, no matter which version you upgrade to.
+
+## Notice
+
+I'd like to humbly request you to please refrain from using this module anyplace critical since it hasn't been audited properly and is still undergoing massive changes. You should be able to better rely on it once the v1.x is released.
 
 ## Security Model
 

--- a/test/fixtures/c.js
+++ b/test/fixtures/c.js
@@ -1,0 +1,1 @@
+module.require('util');

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -39,3 +39,8 @@ test('secureRequire should prevent base from doing stuff', () => {
 test('secureRequire should not prevent base from doing stuff if permissions are granted', () => {
   expect(() => secureRequire('base', ['util'])).not.toThrow();
 });
+
+test('module require should be available inside require but not secureRequire', () => {
+  expect(() => secureRequire('../test/fixtures/c')).toThrow();
+  expect(() => require('../test/fixtures/c')).not.toThrow();
+});


### PR DESCRIPTION
Fix a security vulnerability that allowed the untrusted module to use `Module.prototype.require` in order to require modules irrespective of permissions.

/cc @bengl