### PR TITLE
Added two failing tests for altering core via __proto__

### DIFF
--- a/test/fixtures/h.js
+++ b/test/fixtures/h.js
@@ -1,0 +1,5 @@
+const EventEmitter = require('events');
+
+const emitter = new EventEmitter();
+
+emitter.__proto__.on = (event) => event === 'myevent' && console.error('REPLACED EventEmitter.on!', event);

--- a/test/fixtures/i.js
+++ b/test/fixtures/i.js
@@ -1,0 +1,3 @@
+require.__proto__.call = function() {
+    console.error('REPLACED Function.prototype.call');
+}

--- a/test/vuln.test.ts
+++ b/test/vuln.test.ts
@@ -38,3 +38,24 @@ test('04 - module should not be able to require the Module class, even if it is 
     require('./fixtures/g');
   }).not.toThrow();
 });
+
+test.skip('05 - module should not be able to alter core via called or constructed functions.', () => {
+  /*
+  secureRequire('./fixtures/h', ['events']);
+  const Emitter = require('events');
+  new Emitter().on('myevent'); // logs "REPLACED ..."
+  */
+  expect(() => {
+    secureRequire('./fixtures/h', ['events']);
+  }).toThrow();
+});
+
+test.skip('06 - module should not be able to alter core via provided require() function.', () => {
+  /*
+  secureRequire('./fixtures/i', []);
+  (function a() {}).call({});// logs "REPLACED ..."
+  */
+  expect(() => {
+    secureRequire('./fixtures/i', []);
+  }).toThrow();
+});


### PR DESCRIPTION
Added some skipped (failing) tests for vulnerabilities through `__proto__`. Fixing it would require your validator Proxy to also wrap functions on `apply` and `construct` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy

Separate from these tests, but there's likely also vulnerabilities on `setPrototypeOf`, `preventExtensions`, `defineProperty`, and `deleteProperty` which need to `throw`. And the getter Proxy traps should probably also return Proxy'd versions.

The more I look at this, the more complicated the sandboxing gets. :) I think it'd take a lot of work to _actually_ create a secure require. I haven't really looked carefully at any of the other problems I mentioned previously. I think the fs+eval one isn't a legitimate hole, though, so that's good.

Also separate from this PR, but it feels like providing some kind of permissioning/access to, for example, `process.env` and `Buffer` would be useful. All the default Node globals being absent would limit this API a bit.

Btw, the contexts test fails in 10.13.0, but I'm guessing it works in newer versions of Node? `compileFunction` in 10.13.0 uses the `parsingContext` for compile, but not when you actually `call()` the function.

Best of luck!