### PR TITLE
forbid requires of binary extensions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -67,6 +67,11 @@ export default function secureRequire(
     parent || module,
     false
   );
+  
+  if (filename.endsWith('.node')) {
+    return null;
+  }
+
   const cached = cache![filename];
   if (cached) {
     return cached.exports;


### PR DESCRIPTION
Since binary extensions can do anything they please, return null when requiring them.

I haven't tested it, but according to [the docs](https://nodejs.org/api/modules.html#modules_all_together) a file is only loaded as a binary extension if it's a `.node` file.